### PR TITLE
Downgrade Discord.py to 1.7.3 #3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-discord.py
+discord.py==1.7.3


### PR DESCRIPTION
`TypeError: Client.run() got an unexpected keyword argument 'bot'`

`self-bot` has been discontinued in the latest Discord.py version.

Still works with Discord.py 1.7.3 version from 2021